### PR TITLE
Allow server to send 201 on PATCH create

### DIFF
--- a/test/surface/create.test.ts
+++ b/test/surface/create.test.ts
@@ -386,7 +386,7 @@ describe('Create', () => {
         "<#patch> a solid:InsertDeletePatch;\n" +
         "  solid:inserts { <#hello> <#linked> <#world> .}.\n",
       });
-      expect(result.status).toEqual(200);
+      expect(responseCodeGroup(result.status)).toEqual('2xx');
     });
 
     it(`is disallowed without Write or Append on c/`, async () => {
@@ -625,7 +625,7 @@ describe('Create', () => {
         "<#patch> a solid:InsertDeletePatch;\n" +
         "  solid:inserts { <#hello> <#linked> <#world> .}.\n",
       });
-      expect(result.status).toEqual(200);
+      expect(responseCodeGroup(result.status)).toEqual('2xx');
     });
 
     it(`is allowed with Append on c/`, async () => {


### PR DESCRIPTION
When a new resource is created as a result of PATCH, allow 201 as a valid status code.